### PR TITLE
Adding FASTA dump for all splits/datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains the AutoEval module, which allows to auto evaluate FLIP
 
 Together with the scripts, this repository also contains a bank of optimal or base configurations (in the `configsbank` folder) for each of the available datasets in FLIP. These configuration files are general versions for each dataset and they are modified by the script. The expected to be usually changed parameters (embedder_name and model_choice) can be changed using input parameters. A different configuration file can be used using the input parameters, as explained below.
 
+[Here](http://data.bioembeddings.com/public/FLIP/fasta/) are available all the FLIP datasets in FASTA format for, e.g., those cases that it is needed to obtain different embeddings from the ones available in bio-embeddings, and the FASTA files are required. When different embeddings or modifications to the data are not required, AutoEval automatically converts FLIP CSV format to FASTA (or reads directly those datasets already in FASTA).
+
 ## How to run AutoEval
 
 AutoEval can be executed:
@@ -45,7 +47,7 @@ python run-autoeval.py scl_1 residues_to_class ./scl_1 --embedder prottrans_t5_x
 - via Docker:
 
 ```bash
-?
+-
 ```
 
 The available input parameters are:

--- a/autoeval/managers/data.py
+++ b/autoeval/managers/data.py
@@ -97,7 +97,7 @@ def residues_to_class_fasta(split_dir: str, destination_sequences_dir: str):
         for index, row in split.iterrows():
             validation = 'True' if row['validation'] == True else 'False'
 
-            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'], row['set'], validation))
+            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'].replace(' ', '_'), row['set'], validation))
             sequences_file.write('{}\n'.format(row['sequence']))
 
 def protein_to_class_fasta(split_dir: str, destination_sequences_dir: str):
@@ -114,7 +114,7 @@ def protein_to_class_fasta(split_dir: str, destination_sequences_dir: str):
         for index, row in split.iterrows():
             validation = 'True' if row['validation'] == True else 'False'
 
-            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'], row['set'], validation))
+            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'].replace(' ', '_'), row['set'], validation))
             sequences_file.write('{}\n'.format(row['sequence']))
 
 def protein_to_value_fasta(split_dir: str, destination_sequences_dir: str):
@@ -179,11 +179,11 @@ def prepare_data(split: str, protocol: str, working_dir: str, min_size: int, max
 
         if protocol == 'sequence_to_class':
             logger.info('Converting CSV to FASTA for sequence to class protocol.')
-            protein_to_value_fasta(split_dir, destination_sequences_dir)
+            protein_to_class_fasta(split_dir, destination_sequences_dir)
             destination_labels_dir = None
         elif protocol == 'sequence_to_value':
             logger.info('Converting CSV to FASTA for sequence to value protocol.')
-            protein_to_class_fasta(split_dir, destination_sequences_dir)
+            protein_to_value_fasta(split_dir, destination_sequences_dir)
             destination_labels_dir = None
         elif protocol == 'residues_to_class':
             logger.info('Converting CSV to FASTA for residues to class protocol.')

--- a/legacy/all_flip_to_fasta.sh
+++ b/legacy/all_flip_to_fasta.sh
@@ -1,53 +1,55 @@
 # AAV
 echo "Converting AAV..."
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file mut_des.csv --output_location ./all_fasta/aav
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file des_mut.csv --output_location ./all_fasta/aav
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file one_vs_many.csv --output_location ./all_fasta/aav
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file two_vs_many.csv --output_location ./all_fasta/aav
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file seven_vs_many.csv --output_location ./all_fasta/aav
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file low_vs_high.csv --output_location ./all_fasta/aav
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file sampled.csv --output_location ./all_fasta/aav
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file mut_des.csv --output_location ./all_fasta/aav
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file des_mut.csv --output_location ./all_fasta/aav
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file one_vs_many.csv --output_location ./all_fasta/aav
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file two_vs_many.csv --output_location ./all_fasta/aav
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file seven_vs_many.csv --output_location ./all_fasta/aav
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file low_vs_high.csv --output_location ./all_fasta/aav
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file sampled.csv --output_location ./all_fasta/aav
 
-# Meltomeecho "Converting Meltome..."
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/meltome/splits/ --split_file human_cell.csv --output_location ./all_fasta/meltome
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/meltome/splits/ --split_file human.csv --output_location ./all_fasta/meltome
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/meltome/splits/ --split_file mixed_split.csv --output_location ./all_fasta/meltome
+# Meltome
+echo "Converting Meltome..."
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/meltome/splits/ --split_file human_cell.csv --output_location ./all_fasta/meltome
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/meltome/splits/ --split_file human.csv --output_location ./all_fasta/meltome
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/meltome/splits/ --split_file mixed_split.csv --output_location ./all_fasta/meltome
 
-# GB1echo "Converting GB1..."
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file one_vs_rest.csv --output_location ./all_fasta/gb1
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file two_vs_rest.csv --output_location ./all_fasta/gb1
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file three_vs_rest.csv --output_location ./all_fasta/gb1
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file low_vs_high.csv --output_location ./all_fasta/gb1
-python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file sampled.csv --output_location ./all_fasta/gb1
+# GB1
+echo "Converting GB1..."
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file one_vs_rest.csv --output_location ./all_fasta/gb1
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file two_vs_rest.csv --output_location ./all_fasta/gb1
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file three_vs_rest.csv --output_location ./all_fasta/gb1
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file low_vs_high.csv --output_location ./all_fasta/gb1
+python flip_csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file sampled.csv --output_location ./all_fasta/gb1
 
 #SLC
 echo "Converting SCL..."
-python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_soft.csv --output_location ./all_fasta/scl
-python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_hard.csv --output_location ./all_fasta/scl
-python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file human_soft.csv --output_location ./all_fasta/scl
-python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file human_hard.csv --output_location ./all_fasta/scl
-python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file balanced.csv --output_location ./all_fasta/scl
-python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_vs_human_2.csv --output_location ./all_fasta/scl
+python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_soft.csv --output_location ./all_fasta/scl
+python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_hard.csv --output_location ./all_fasta/scl
+python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file human_soft.csv --output_location ./all_fasta/scl
+python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file human_hard.csv --output_location ./all_fasta/scl
+python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file balanced.csv --output_location ./all_fasta/scl
+python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_vs_human_2.csv --output_location ./all_fasta/scl
 
 # Bind
 echo "Converting Bind..."
-python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_many.fasta --output_location ./all_fasta/bind
-python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file two_vs_many.fasta --output_location ./all_fasta/bind
-python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file from_publication.fasta --output_location ./all_fasta/bind
-python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_mn.fasta --output_location ./all_fasta/Bind
-python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_sm.fasta --output_location ./all_fasta/bind
-python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_sn.fasta --output_location ./all_fasta/bind
+python flip_csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_many.fasta --output_location ./all_fasta/bind
+python flip_csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file two_vs_many.fasta --output_location ./all_fasta/bind
+python flip_csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file from_publication.fasta --output_location ./all_fasta/bind
+python flip_csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_mn.fasta --output_location ./all_fasta/Bind
+python flip_csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_sm.fasta --output_location ./all_fasta/bind
+python flip_csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_sn.fasta --output_location ./all_fasta/bind
 
 # SAV
 echo "Converting SAV..."
-python csv_to_fasta.py --protocol sequence_to_class --task_location ../autoeval/FLIP/splits/sav/splits/ --split_file mixed.csv --output_location ./all_fasta/sav
-python csv_to_fasta.py --protocol sequence_to_class --task_location ../autoeval/FLIP/splits/sav/splits/ --split_file human.csv --output_location ./all_fasta/sav
-python csv_to_fasta.py --protocol sequence_to_class --task_location ../autoeval/FLIP/splits/sav/splits/ --split_file only_savs.csv --output_location ./all_fasta/sav
+python flip_csv_to_fasta.py --protocol sequence_to_class --task_location ../autoeval/FLIP/splits/sav/splits/ --split_file mixed.csv --output_location ./all_fasta/sav
+python flip_csv_to_fasta.py --protocol sequence_to_class --task_location ../autoeval/FLIP/splits/sav/splits/ --split_file human.csv --output_location ./all_fasta/sav
+python flip_csv_to_fasta.py --protocol sequence_to_class --task_location ../autoeval/FLIP/splits/sav/splits/ --split_file only_savs.csv --output_location ./all_fasta/sav
 
 # Secondary structure
 echo "Converting Secondary structure..."
-python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/secondary_structure/splits/ --split_file sampled.fasta --output_location ./all_fasta/secondary_structure
+python flip_csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/secondary_structure/splits/ --split_file sampled.fasta --output_location ./all_fasta/secondary_structure
 
 # Conservation
 echo "Converting Conservation..."
-python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/conservation/splits/ --split_file sampled.fasta --output_location ./all_fasta/conservation
+python flip_csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/conservation/splits/ --split_file sampled.fasta --output_location ./all_fasta/conservation

--- a/legacy/all_flip_to_fasta.sh
+++ b/legacy/all_flip_to_fasta.sh
@@ -29,7 +29,7 @@ python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../auto
 python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file human_soft.csv --output_location ./all_fasta/scl
 python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file human_hard.csv --output_location ./all_fasta/scl
 python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file balanced.csv --output_location ./all_fasta/scl
-python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_vs_human_2.csv --output_location ./all_fasta/scl
+#python flip_csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_vs_human_2.csv --output_location ./all_fasta/scl
 
 # Bind
 echo "Converting Bind..."

--- a/legacy/all_flip_to_fasta.sh
+++ b/legacy/all_flip_to_fasta.sh
@@ -1,0 +1,53 @@
+# AAV
+echo "Converting AAV..."
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file mut_des.csv --output_location ./all_fasta/aav
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file des_mut.csv --output_location ./all_fasta/aav
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file one_vs_many.csv --output_location ./all_fasta/aav
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file two_vs_many.csv --output_location ./all_fasta/aav
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file seven_vs_many.csv --output_location ./all_fasta/aav
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file low_vs_high.csv --output_location ./all_fasta/aav
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/aav/splits/ --split_file sampled.csv --output_location ./all_fasta/aav
+
+# Meltomeecho "Converting Meltome..."
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/meltome/splits/ --split_file human_cell.csv --output_location ./all_fasta/meltome
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/meltome/splits/ --split_file human.csv --output_location ./all_fasta/meltome
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/meltome/splits/ --split_file mixed_split.csv --output_location ./all_fasta/meltome
+
+# GB1echo "Converting GB1..."
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file one_vs_rest.csv --output_location ./all_fasta/gb1
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file two_vs_rest.csv --output_location ./all_fasta/gb1
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file three_vs_rest.csv --output_location ./all_fasta/gb1
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file low_vs_high.csv --output_location ./all_fasta/gb1
+python csv_to_fasta.py --protocol sequence_to_value --task_location ../autoeval/FLIP/splits/gb1/splits/ --split_file sampled.csv --output_location ./all_fasta/gb1
+
+#SLC
+echo "Converting SCL..."
+python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_soft.csv --output_location ./all_fasta/scl
+python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_hard.csv --output_location ./all_fasta/scl
+python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file human_soft.csv --output_location ./all_fasta/scl
+python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file human_hard.csv --output_location ./all_fasta/scl
+python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file balanced.csv --output_location ./all_fasta/scl
+python csv_to_fasta.py --protocol residues_to_class --task_location ../autoeval/FLIP/splits/scl/splits/ --split_file mixed_vs_human_2.csv --output_location ./all_fasta/scl
+
+# Bind
+echo "Converting Bind..."
+python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_many.fasta --output_location ./all_fasta/bind
+python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file two_vs_many.fasta --output_location ./all_fasta/bind
+python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file from_publication.fasta --output_location ./all_fasta/bind
+python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_mn.fasta --output_location ./all_fasta/Bind
+python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_sm.fasta --output_location ./all_fasta/bind
+python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/bind/splits/ --split_file one_vs_sn.fasta --output_location ./all_fasta/bind
+
+# SAV
+echo "Converting SAV..."
+python csv_to_fasta.py --protocol sequence_to_class --task_location ../autoeval/FLIP/splits/sav/splits/ --split_file mixed.csv --output_location ./all_fasta/sav
+python csv_to_fasta.py --protocol sequence_to_class --task_location ../autoeval/FLIP/splits/sav/splits/ --split_file human.csv --output_location ./all_fasta/sav
+python csv_to_fasta.py --protocol sequence_to_class --task_location ../autoeval/FLIP/splits/sav/splits/ --split_file only_savs.csv --output_location ./all_fasta/sav
+
+# Secondary structure
+echo "Converting Secondary structure..."
+python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/secondary_structure/splits/ --split_file sampled.fasta --output_location ./all_fasta/secondary_structure
+
+# Conservation
+echo "Converting Conservation..."
+python csv_to_fasta.py --protocol residue_to_class --task_location ../autoeval/FLIP/splits/conservation/splits/ --split_file sampled.fasta --output_location ./all_fasta/conservation

--- a/legacy/flip_csv_to_fasta.py
+++ b/legacy/flip_csv_to_fasta.py
@@ -1,0 +1,121 @@
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+from pandas import read_csv
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description = "Script to systematically convert FLIP CSV data to FASTA format")
+    parser.add_argument('--protocol', type=str, required=True)
+    parser.add_argument('--task_location', type=str, required=True)
+    parser.add_argument('--split_file', type=str, required=True)
+    parser.add_argument('--output_location', type=str, required=True)
+    
+    return parser
+
+def residue_to_class_fasta(split_dir: str, destination_sequences_dir: str, destination_labels_dir: str):
+    """
+    Converts FLIP CSV files to biotrainer FASTA files for the residue to class protocol.
+
+    :param split_dir: path to a valid FLIP split directory
+    :param destination_sequences_dir: path to the destination FASTA file for the sequences
+    :param destination_labels_dir: path to the destination FASTA file for the labels
+    """
+    split = read_csv(split_dir)
+
+    # Create sequences.fasta
+    with open(destination_sequences_dir, 'w') as sequences_file:
+        for index, row in split.iterrows():
+            sequences_file.write('>{}\n'.format('Sequence{}'.format(index)))
+            sequences_file.write('{}\n'.format(row['sequence']))
+
+    # Create labels.fasta
+    with open(destination_labels_dir, 'w') as labels_file:
+        for index, row in split.iterrows():
+            validation = 'True' if row['validation'] == True else 'False'
+            labels_file.write('>{}\n'.format('Sequence{} SET={} VALIDATION={}'.format(index, row['set'], validation)))
+            labels_file.write('{}\n'.format(row['target']))
+
+def residues_to_class_fasta(split_dir: str, destination_sequences_dir: str):
+    """
+    Converts FLIP CSV file to biotrainet FASTA file for the residues to class protocol.
+
+    :param split_dir: path to a valid FLIP split directory
+    :param destination_sequences_dir: path to the destination FASTA file for the sequences
+    """
+    split = read_csv(split_dir)
+
+    # Create sequences.fasta
+    with open(destination_sequences_dir, 'w') as sequences_file:
+        for index, row in split.iterrows():
+            validation = 'True' if row['validation'] == True else 'False'
+
+            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'], row['set'], validation))
+            sequences_file.write('{}\n'.format(row['sequence']))
+
+def protein_to_class_fasta(split_dir: str, destination_sequences_dir: str):
+    """
+    Converts FLIP CSV file to biotrainer FASTA file for the protein to class protocol.
+
+    :param split_dir: path to a valid FLIP split directory
+    :param destination_sequences_dir: path to the destination FASTA file for the sequences
+    """
+    split = read_csv(split_dir)
+
+    # Create sequences.fasta
+    with open(destination_sequences_dir, 'w') as sequences_file:
+        for index, row in split.iterrows():
+            validation = 'True' if row['validation'] == True else 'False'
+
+            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'], row['set'], validation))
+            sequences_file.write('{}\n'.format(row['sequence']))
+
+def protein_to_value_fasta(split_dir: str, destination_sequences_dir: str):
+    """
+    Converts FLIP CSV file to biotrainer FASTA file for the protein to value protocol.
+
+    :param split_dir: path to a valid FLIP split directory
+    :param destination_sequences_dir: path to the destination FASTA file for the sequences
+    """
+    split = read_csv(split_dir)
+
+    # Create sequences.fasta
+    with open(destination_sequences_dir, 'w') as sequences_file:
+        for index, row in split.iterrows():
+            validation = 'True' if row['validation'] == True else 'False'
+            
+            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'], row['set'], validation))
+            sequences_file.write('{}\n'.format(row['sequence']))
+
+if __name__ == "__main__":
+
+    parser = create_parser()
+    arguments = parser.parse_args()
+
+    # Check if the split is already in FASTA format. If already in FASTA, it at least contains the sequences.fasta file
+    if os.path.exists(Path(arguments.task_location) / 'sequences.fasta'):
+        #logger.info('Split already in FASTA format. Conversion not needed. Copying files direclty.')
+        shutil.copyfile(Path(arguments.task_location) / 'sequences.fasta', Path(arguments.output_location) / 'sequences.fasta')
+        
+        if arguments.protocol == 'residue_to_class':
+            shutil.copyfile(Path(arguments.task_location) / arguments.split_file, Path(arguments.output_location) / arguments.split_file)
+
+        # Check if exists a mask file. If exists, copy it to the working directory
+        if os.path.exists(Path(arguments.task_location) / 'mask.fasta'):
+            shutil.copyfile(Path(arguments.task_location) / 'mask.fasta', Path(arguments.output_location) / 'mask.fasta')
+
+    else:
+        # If the split is not already in FASTA format we convert CSV to FASTA
+        split_dir = Path(arguments.task_location) / arguments.split_file
+        sequences_dir = Path(arguments.output_location) / arguments.split_file.replace('.csv', '.fasta')
+
+        if arguments.protocol == 'sequence_to_class':
+            protein_to_value_fasta(split_dir, sequences_dir)
+        elif arguments.protocol == 'sequence_to_value':
+            protein_to_class_fasta(split_dir, sequences_dir)
+        elif arguments.protocol == 'residues_to_class':
+            residues_to_class_fasta(split_dir, sequences_dir)
+        elif arguments.protocol == 'residue_to_class':
+            residue_to_class_fasta(split_dir, sequences_dir, Path(arguments.output_location) / arguments.split_file)

--- a/legacy/flip_csv_to_fasta.py
+++ b/legacy/flip_csv_to_fasta.py
@@ -52,7 +52,7 @@ def residues_to_class_fasta(split_dir: str, destination_sequences_dir: str):
         for index, row in split.iterrows():
             validation = 'True' if row['validation'] == True else 'False'
 
-            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'], row['set'], validation))
+            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'].replace(' ', '_'), row['set'], validation))
             sequences_file.write('{}\n'.format(row['sequence']))
 
 def protein_to_class_fasta(split_dir: str, destination_sequences_dir: str):
@@ -69,7 +69,7 @@ def protein_to_class_fasta(split_dir: str, destination_sequences_dir: str):
         for index, row in split.iterrows():
             validation = 'True' if row['validation'] == True else 'False'
 
-            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'], row['set'], validation))
+            sequences_file.write('>Sequence{} TARGET={} SET={} VALIDATION={}\n'.format(index, row['target'].replace(' ', '_'), row['set'], validation))
             sequences_file.write('{}\n'.format(row['sequence']))
 
 def protein_to_value_fasta(split_dir: str, destination_sequences_dir: str):
@@ -94,6 +94,10 @@ if __name__ == "__main__":
     parser = create_parser()
     arguments = parser.parse_args()
 
+    # Create output directory
+    if not os.path.exists(arguments.output_location):
+        os.makedirs(arguments.output_location, exist_ok=True)
+
     # Check if the split is already in FASTA format. If already in FASTA, it at least contains the sequences.fasta file
     if os.path.exists(Path(arguments.task_location) / 'sequences.fasta'):
         #logger.info('Split already in FASTA format. Conversion not needed. Copying files direclty.')
@@ -112,9 +116,9 @@ if __name__ == "__main__":
         sequences_dir = Path(arguments.output_location) / arguments.split_file.replace('.csv', '.fasta')
 
         if arguments.protocol == 'sequence_to_class':
-            protein_to_value_fasta(split_dir, sequences_dir)
-        elif arguments.protocol == 'sequence_to_value':
             protein_to_class_fasta(split_dir, sequences_dir)
+        elif arguments.protocol == 'sequence_to_value':
+            protein_to_value_fasta(split_dir, sequences_dir)
         elif arguments.protocol == 'residues_to_class':
             residues_to_class_fasta(split_dir, sequences_dir)
         elif arguments.protocol == 'residue_to_class':


### PR DESCRIPTION
Once applied, this PR will:

1. Add scripts (legacy) to automatically convert FLIP files to FASTA files.
2. Solve the problem detected when writing the TARGET in FASTA files (‘ ‘ -> ‘_’).
3. Add a link (in the README file) to a ZIP file with the entire FLIP in FASTA format.